### PR TITLE
fix: prefer header match over column letter for ambiguous keys

### DIFF
--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -411,9 +411,12 @@ export async function appendRows(
 
   const normalizedKeyToValue = new Map<string, unknown>();
   const colNumberToValue = new Map<number, unknown>();
+  const headerNorms = layout.hasHeader
+    ? new Set(layout.rawHeaders.map((h) => normalizeHeader(h)))
+    : null;
   for (const [key, val] of Object.entries(values)) {
     normalizedKeyToValue.set(normalizeHeader(key), val);
-    if (isColumnLetter(key)) {
+    if (isColumnLetter(key) && !headerNorms?.has(normalizeHeader(key))) {
       const colNum = colLetterToNumber(key);
       if (Number.isFinite(colNum)) {
         colNumberToValue.set(colNum, val);
@@ -543,15 +546,16 @@ export async function updateByRowIndex(
 
   for (const [key, val] of Object.entries(setValues)) {
     let colNum: number | null = null;
-    if (isColumnLetter(key)) {
-      const parsed = colLetterToNumber(key);
-      colNum = Number.isFinite(parsed) ? parsed : null;
-    } else if (layout.hasHeader) {
+    if (layout.hasHeader) {
       const normalizedKey = normalizeHeader(key);
       const colIdx = layout.rawHeaders.findIndex(
         (h) => normalizeHeader(h) === normalizedKey
       );
       colNum = colIdx === -1 ? null : layout.startCol + colIdx;
+    }
+    if (colNum === null && isColumnLetter(key)) {
+      const parsed = colLetterToNumber(key);
+      colNum = Number.isFinite(parsed) ? parsed : null;
     }
 
     if (!colNum) {
@@ -617,15 +621,16 @@ export async function updateByKey(
   );
 
   let keyColNum: number | null = null;
-  if (isColumnLetter(keyCol)) {
-    const parsed = colLetterToNumber(keyCol);
-    keyColNum = Number.isFinite(parsed) ? parsed : null;
-  } else if (layout.hasHeader) {
+  if (layout.hasHeader) {
     const normalizedKeyCol = normalizeHeader(keyCol);
     const keyColIdx = layout.rawHeaders.findIndex(
       (h) => normalizeHeader(h) === normalizedKeyCol
     );
     keyColNum = keyColIdx === -1 ? null : layout.startCol + keyColIdx;
+  }
+  if (keyColNum === null && isColumnLetter(keyCol)) {
+    const parsed = colLetterToNumber(keyCol);
+    keyColNum = Number.isFinite(parsed) ? parsed : null;
   }
 
   if (!keyColNum) {
@@ -671,15 +676,16 @@ export async function updateByKey(
   for (const rowNum of matchingRows) {
     for (const [key, val] of Object.entries(setValues)) {
       let colNum: number | null = null;
-      if (isColumnLetter(key)) {
-        const parsed = colLetterToNumber(key);
-        colNum = Number.isFinite(parsed) ? parsed : null;
-      } else if (layout.hasHeader) {
+      if (layout.hasHeader) {
         const normalizedKey = normalizeHeader(key);
         const colIdx = layout.rawHeaders.findIndex(
           (h) => normalizeHeader(h) === normalizedKey
         );
         colNum = colIdx === -1 ? null : layout.startCol + colIdx;
+      }
+      if (colNum === null && isColumnLetter(key)) {
+        const parsed = colLetterToNumber(key);
+        colNum = Number.isFinite(parsed) ? parsed : null;
       }
 
       if (!colNum) {


### PR DESCRIPTION
## Summary

- Headers matching `/^[A-Za-z]{1,3}$/` (e.g. `ID`, `URL`) were misinterpreted as column letter references, inflating row width to hundreds of empty columns on `append`
- Root cause: `isColumnLetter()` matches any 1-3 letter string — `ID` resolves to column 238, `URL` to column 14676
- Fix: header name match now takes priority; column letter interpretation is fallback only when no header matches
- All 4 affected sites fixed: `appendRows`, `updateByRowIndex`, `updateByKey` (keyCol + setValues)

Closes #1

## Test plan

- [x] Regression test: `appendRows` with `ID`/`URL` headers produces correct 6-column row
- [x] Regression test: `updateByRowIndex` with `ID` header targets column A, not column 238
- [x] Existing tests pass (93/93)
- [x] Lint clean